### PR TITLE
Sync kodi ebuilds

### DIFF
--- a/media-tv/kodi/files/kodi-21.1-fix-swig-4.3.0-build-pr25863.patch
+++ b/media-tv/kodi/files/kodi-21.1-fix-swig-4.3.0-build-pr25863.patch
@@ -1,0 +1,27 @@
+From: https://github.com/xbmc/xbmc/pull/25863
+From 4ff0ba903bed472cddb0d6e5c53c8176cded6b09 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Mon, 21 Oct 2024 22:10:29 +1100
+Subject: [PATCH] [swig] Fix building with swig 4.3.0
+
+swig 4.3.0 has dropped the -xmllang option used with -xml, which had no effect on the output.
+
+Ref:
+- https://github.com/swig/swig/commit/86498e46c6a6218a3d091c12513c40076ac2ce63
+---
+ xbmc/interfaces/swig/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/xbmc/interfaces/swig/CMakeLists.txt b/xbmc/interfaces/swig/CMakeLists.txt
+index 1951b2a336789..46c84c7f7efc5 100644
+--- a/xbmc/interfaces/swig/CMakeLists.txt
++++ b/xbmc/interfaces/swig/CMakeLists.txt
+@@ -22,7 +22,7 @@ function(generate_file file)
+ 
+   add_custom_command(OUTPUT ${CPP_FILE}
+                      COMMAND ${SWIG_EXECUTABLE}
+-                     ARGS -w401 -c++ -o ${file}.xml -xml -I${CMAKE_SOURCE_DIR}/xbmc -xmllang python ${CMAKE_CURRENT_SOURCE_DIR}/../swig/${file}
++                     ARGS -w401 -c++ -o ${file}.xml -xml -I${CMAKE_SOURCE_DIR}/xbmc ${CMAKE_CURRENT_SOURCE_DIR}/../swig/${file}
+                      COMMAND ${Java_JAVA_EXECUTABLE}
+                      ARGS ${JAVA_OPEN_OPTS} -cp "${classpath}" groovy.ui.GroovyMain ${CMAKE_SOURCE_DIR}/tools/codegenerator/Generator.groovy ${file}.xml ${CMAKE_CURRENT_SOURCE_DIR}/../python/PythonSwig.cpp.template ${file}.cpp > ${devnull}
+                      ${CLANG_FORMAT_COMMAND}

--- a/media-tv/kodi/files/kodi-21.2-pipewire-1.4.0-fix.patch
+++ b/media-tv/kodi/files/kodi-21.2-pipewire-1.4.0-fix.patch
@@ -1,0 +1,27 @@
+https://github.com/xbmc/xbmc/issues/26526
+https://github.com/xbmc/xbmc/commit/269053ebbfd3cc4a3156a511f54ab7f08a09a730
+https://github.com/xbmc/xbmc/pull/26502
+https://github.com/xbmc/xbmc/pull/26527
+
+From e23a105b8988aba9b8401493bf6031a6878bd435 Mon Sep 17 00:00:00 2001
+From: Timo Gurr <timo.gurr@gmail.com>
+Date: Fri, 7 Mar 2025 13:30:47 +0100
+Subject: [PATCH] [AudioEngine] PipeWire: Fix build with PipeWire 1.4.0
+
+PipeWire >= 1.4.0 requires the correct struct type to be used, otherwise
+it will fail to compile.
+
+Reference: https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/188d920733f0791413d3386e5536ee7377f71b2f
+(cherry picked from commit 269053ebbfd3cc4a3156a511f54ab7f08a09a730)
+--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
++++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
+@@ -40,7 +40,8 @@ void CPipewireNode::EnumerateFormats()
+   for (uint32_t param = 0; param < m_info->n_params; param++)
+   {
+     if (m_info->params[param].id == SPA_PARAM_EnumFormat)
+-      pw_node_enum_params(m_proxy.get(), 0, m_info->params[param].id, 0, 0, NULL);
++      pw_node_enum_params(reinterpret_cast<struct pw_node*>(m_proxy.get()), 0,
++                          m_info->params[param].id, 0, 0, NULL);
+   }
+ }
+ 

--- a/media-tv/kodi/kodi-21.1-r2.ebuild
+++ b/media-tv/kodi/kodi-21.1-r2.ebuild
@@ -273,6 +273,7 @@ PATCHES=(
 	"${FILESDIR}"/kodi-21-optional-ffmpeg-libx11.patch
 	"${FILESDIR}"/kodi-21.1-silence-libdvdread-git.patch
 	"${FILESDIR}"/kodi-21.1-fix-gcc15.patch
+	"${FILESDIR}"/kodi-21.1-fix-swig-4.3.0-build-pr25863.patch
 )
 
 # bug #544020

--- a/media-tv/kodi/kodi-21.2-r2.ebuild
+++ b/media-tv/kodi/kodi-21.2-r2.ebuild
@@ -333,10 +333,6 @@ src_prepare() {
 }
 
 src_configure() {
-	# TODO: drop compat and allow using >=media-video/ffmpeg-7
-	ffmpeg_compat_setup 6
-	ffmpeg_compat_add_flags
-
 	local core_platform=(
 		$(usev gbm)
 		$(usev wayland)
@@ -441,6 +437,11 @@ src_configure() {
 		local name=${flag#cpu_flags_*_}
 		mycmakeargs+=( -DENABLE_${name^^}=$(usex ${flag}) )
 	done
+
+	# TODO: drop compat and allow using >=media-video/ffmpeg-7
+	ffmpeg_compat_setup 6
+	ffmpeg_compat_add_flags
+	mycmakeargs+=( -DFFMPEG_INCLUDE_DIRS="${SYSROOT}$(ffmpeg_compat_get_prefix 6)" )
 
 	if ! is-flag -DNDEBUG && ! is-flag -D_DEBUG ; then
 		# Kodi requires one of the 'NDEBUG' or '_DEBUG' defines

--- a/media-tv/kodi/kodi-21.2-r2.ebuild
+++ b/media-tv/kodi/kodi-21.2-r2.ebuild
@@ -272,6 +272,7 @@ BDEPEND="
 PATCHES=(
 	"${FILESDIR}"/kodi-21-optional-ffmpeg-libx11.patch
 	"${FILESDIR}"/kodi-21.1-silence-libdvdread-git.patch
+	"${FILESDIR}"/kodi-21.2-pipewire-1.4.0-fix.patch
 )
 
 # bug #544020

--- a/media-tv/kodi/kodi-21.2-r2.ebuild
+++ b/media-tv/kodi/kodi-21.2-r2.ebuild
@@ -439,10 +439,12 @@ src_configure() {
 		mycmakeargs+=( -DENABLE_${name^^}=$(usex ${flag}) )
 	done
 
-	# TODO: drop compat and allow using >=media-video/ffmpeg-7
-	ffmpeg_compat_setup 6
-	ffmpeg_compat_add_flags
-	mycmakeargs+=( -DFFMPEG_INCLUDE_DIRS="${SYSROOT}$(ffmpeg_compat_get_prefix 6)" )
+	if use system-ffmpeg; then
+		# TODO: drop compat and allow using >=media-video/ffmpeg-7
+		ffmpeg_compat_setup 6
+		ffmpeg_compat_add_flags
+		mycmakeargs+=( -DFFMPEG_INCLUDE_DIRS="${SYSROOT}$(ffmpeg_compat_get_prefix 6)" )
+	fi
 
 	if ! is-flag -DNDEBUG && ! is-flag -D_DEBUG ; then
 		# Kodi requires one of the 'NDEBUG' or '_DEBUG' defines


### PR DESCRIPTION
@dguglielmi What would you think about removing the non live kodi ebuilds? Less backporting from ::gentoo